### PR TITLE
Precalculate mask in simulation of ALTRO chip

### DIFF
--- a/src/altro.cpp
+++ b/src/altro.cpp
@@ -406,7 +406,7 @@ int Altro::multiply36(int P, int N)
   long long temp = 0;
   long long AX = 0;
   temp = (long long)P * (long long)N;
-  AX = (( mask(temp, 35, 18) + ((long long)(-P) << 18) ) + mask(temp, 17, 0));
+  AX = (( mask_35_18(temp) + ((long long)(-P) << 18) ) + mask_17_0(temp));
 
   if ( maskandshift(N, 17, 17) == 1) {
     retval = ((maskandshift(AX, 35, 35) << 17) + maskandshift(AX, 32, 16));
@@ -450,16 +450,16 @@ void Altro::TailCancellationFilter_FixedPoint(int K1, int K2, int K3, int L1, in
     din = channelShort[i];
 
     din = (din << 2);
-    c1n             = mask( (mask(din, 17, 0) + multiply36(K1, mask(c1o, 17, 0)) ), 17, 0);
-    d1              = mask( (mask(c1n, 17, 0) - multiply36(L1, mask(c1o, 17, 0)) ), 17, 0);
+    c1n             = mask_17_0( (mask_17_0(din) + multiply36(K1, mask_17_0(c1o)) ));
+    d1              = mask_17_0( (mask_17_0(c1n) - multiply36(L1, mask_17_0(c1o)) ));
     //d1              = mask( (mask(c1n,17,0) + mask(~multiply36(L1,mask(c1o,17,0))+1,17,0) ) ,17,0);
 
-    c2n             = mask( (mask(d1, 17, 0) + multiply36(K2, mask(c2o, 17, 0)) ), 17, 0);
-    d2              = mask( (mask(c2n, 17, 0) - multiply36(L2, mask(c2o, 17, 0)) ), 17, 0);
+    c2n             = mask_17_0( (mask_17_0(d1)  + multiply36(K2, mask_17_0(c2o)) ));
+    d2              = mask_17_0( (mask_17_0(c2n) - multiply36(L2, mask_17_0(c2o)) ));
     //d2              = mask( (mask(c2n,17,0) + mask(~multiply36(L2,mask(c2o,17,0))+1,17,0) ) ,17,0);
 
-    c3n             = mask( (mask(d2, 17, 0) + multiply36(K3, mask(c3o, 17, 0)) ), 17, 0);
-    dout            = mask( (mask(c3n, 17, 0) - multiply36(L3, mask(c3o, 17, 0)) ), 17, 0);
+    c3n             = mask_17_0( (mask_17_0(d2)  + multiply36(K3, mask_17_0(c3o)) ));
+    dout            = mask_17_0( (mask_17_0(c3n) - multiply36(L3, mask_17_0(c3o)) ));
     //dout            = mask( (mask(c3n,17,0) + mask(~multiply36(L3,mask(c3o,17,0))+1,17,0) ) ,17,0);
 
     if ( (maskandshift(dout, 2, 2) == 1) || (maskandshift(dout, 1, 1) == 1)) {
@@ -473,10 +473,10 @@ void Altro::TailCancellationFilter_FixedPoint(int K1, int K2, int K3, int L1, in
 
     if (maskandshift(dout, 15, 15) == 1) {
       //is needed to get the correct coding when getting negative results
-      dout = -mask((-mask(dout, 9, 0)), 9, 0);
+      dout = -mask_9_0(-mask_9_0(dout));
     }
     else {
-      dout = mask(dout, 9, 0);
+      dout = mask_9_0(dout);
     }
 
     channelShort[i] = (short) dout;

--- a/src/altro.cpp
+++ b/src/altro.cpp
@@ -408,11 +408,11 @@ int Altro::multiply36(int P, int N)
   temp = (long long)P * (long long)N;
   AX = (( mask_35_18(temp) + ((long long)(-P) << 18) ) + mask_17_0(temp));
 
-  if ( maskandshift(N, 17, 17) == 1) {
-    retval = ((maskandshift(AX, 35, 35) << 17) + maskandshift(AX, 32, 16));
+  if ( maskandshift_17_17(N) == 1) {
+    retval = (maskandshift_35_35(AX) << 17) + maskandshift_32_16(AX);
   }
   else {
-    retval = maskandshift(temp, 32, 16);
+    retval = maskandshift_32_16(temp);
   }
 
   return retval;
@@ -462,7 +462,7 @@ void Altro::TailCancellationFilter_FixedPoint(int K1, int K2, int K3, int L1, in
     dout            = mask_17_0( (mask_17_0(c3n) - multiply36(L3, mask_17_0(c3o)) ));
     //dout            = mask( (mask(c3n,17,0) + mask(~multiply36(L3,mask(c3o,17,0))+1,17,0) ) ,17,0);
 
-    if ( (maskandshift(dout, 2, 2) == 1) || (maskandshift(dout, 1, 1) == 1)) {
+    if ( maskandshift_2_2(dout) == 1 || maskandshift_1_1(dout) == 1) {
       bit = 1;
     }
     else {
@@ -471,7 +471,7 @@ void Altro::TailCancellationFilter_FixedPoint(int K1, int K2, int K3, int L1, in
 
     dout = ((dout >> 3) << 1) + bit;
 
-    if (maskandshift(dout, 15, 15) == 1) {
+    if (maskandshift_15_15(dout) == 1) {
       //is needed to get the correct coding when getting negative results
       dout = -mask_9_0(-mask_9_0(dout));
     }

--- a/src/altro.h
+++ b/src/altro.h
@@ -114,5 +114,18 @@ class Altro
   short GetKeepChannel(int i);
   int multiply36(int P, int N);
   long long mask(long long in, int left, int right);
+
+  /// Precalculated masks based on the algorithm implemented in
+  /// `Altro::mask(long long, int left, int right)` and invoked with fixed
+  /// values for the `left` and `right` arguments.
+  ///@{
+  /// left=9, right=0
+  long long mask_9_0(long long in)   { return in & 0b000000000000000000000000001111111111; }
+  /// left=17, right=0
+  long long mask_17_0(long long in)  { return in & 0b000000000000000000111111111111111111; }
+  /// left=35, right=18
+  long long mask_35_18(long long in) { return in & 0b111111111111111111000000000000000000; }
+  ///@}
+
   long long maskandshift(long long in, int left, int right);
 };

--- a/src/altro.h
+++ b/src/altro.h
@@ -128,4 +128,22 @@ class Altro
   ///@}
 
   long long maskandshift(long long in, int left, int right);
+
+  /// Precalculated masks based on the algorithm implemented in
+  /// `Altro::maskandshift(long long, int left, int right)` and invoked with
+  /// fixed values for the `left` and `right` arguments.
+  ///@{
+  /// left=1, right=1
+  long long maskandshift_1_1(long long in)   { return (in >>  1) & 0b000000000000000001; }
+  /// left=2, right=2
+  long long maskandshift_2_2(long long in)   { return (in >>  2) & 0b000000000000000001; }
+  /// left=15, right=15
+  long long maskandshift_15_15(long long in) { return (in >> 15) & 0b000000000000000001; }
+  /// left=17, right=17
+  long long maskandshift_17_17(long long in) { return (in >> 17) & 0b000000000000000001; }
+  /// left=35, right=35
+  long long maskandshift_35_35(long long in) { return (in >> 35) & 0b000000000000000001; }
+  /// left=32, right=16
+  long long maskandshift_32_16(long long in) { return (in >> 16) & 0b011111111111111111; }
+  ///@}
 };


### PR DESCRIPTION
The proposed changes seem to decrease the running time by a significant factor (for now, I was able to measure reliably only in 32-bit build without optimization -O0) across several test samples. These changes are not expected to change produced results.