### PR TITLE
check for requested cxx standard before setting it to c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ OPTION(BUILD_SHARED_LIBS "Global flag to cause add_library to create shared libr
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # A compiler with c++11 support is required
-set(CMAKE_CXX_STANDARD 11)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # This library depends on ROOT

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -3,7 +3,9 @@ cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
 project(TPCRS-EXAMPLE LANGUAGES CXX)
 
 # Request a compiler with c++11 support
-set(CMAKE_CXX_STANDARD 11)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(tpcrs)


### PR DESCRIPTION
This PR replaces
set(CMAKE_CXX_STANDARD 11)
by
if(NOT DEFINED CMAKE_CXX_STANDARD)
  set(CMAKE_CXX_STANDARD 11)
endif()

ROOT includes string_view when using c++17 (needed by ACTS) which bombs when compiled with -std=c++11. The above change allows to use -DCMAKE_CXX_STANDARD=17 to override the default