### PR TITLE
Fix clang

### DIFF
--- a/include/tpcrs/detail/config_structs.h
+++ b/include/tpcrs/detail/config_structs.h
@@ -45,9 +45,9 @@ struct ConfigStruct : Base_t
       Base_t::is_missing = true;
     } else {
       try {
-        rows_.push_back( cfg_.YAML(name).as< Struct_t >() );
+        rows_.push_back( cfg_.YAML(name).template as< Struct_t >() );
       } catch (std::exception& e) {
-        rows_ = cfg_.YAML(name).as< std::vector<Struct_t> >();
+        rows_ = cfg_.YAML(name).template as< std::vector<Struct_t> >();
       }
       Base_t::is_missing = false;
     }
@@ -65,5 +65,11 @@ struct ConfigStruct : Base_t
 
   const Configurator& cfg_;
 };
+
+// suppress warnings in clang (and CLING)
+#if defined(__clang__) || defined(__CLING__)
+template< typename Base_t, typename Chair_t, typename Struct_t >
+  std::string ConfigStruct< Base_t, Chair_t, Struct_t >::name{};
+#endif
 
 }

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -764,7 +764,7 @@ void Simulator::GenerateSignal(const TrackSegment &segment, Coords at_readout, i
   double sigmaJitterT = (tpcrs::IsInner(row, cfg_) ? cfg_.S<TpcResponseSimulator>().SigmaJitterTI :
                                                      cfg_.S<TpcResponseSimulator>().SigmaJitterTO);
 
-  for (unsigned row = rowMin; row <= rowMax; row++) {
+  for (int row = rowMin; row <= rowMax; row++) {
 
     StTpcLocalSectorCoordinate xyzW{at_readout.x, at_readout.y, at_readout.z, sector, row};
     StTpcPadCoordinate Pad;


### PR DESCRIPTION
This PR fixes the compilation with clang where gcc warnings turn to fatal compilation errors. 
include/tpcrs/detail/config_structs.h has a special problem, the 
  static std::string name;
in template<typename Base_t, typename Chair_t, typename Struct_t>
struct ConfigStruct : Base_t
crashes cling and leads to tons of compilation warnings. The only way around those was to add

 template< typename Base_t, typename Chair_t, typename Struct_t >
  std::string ConfigStruct< Base_t, Chair_t, Struct_t >::name{};

to the include file. This then crashes gcc since adding this in the header file leads to multiple declarations seen by the linker. The idea to move this to an implementation (struct_containers.cpp):
template< typename Base_t, typename Chair_t, typename Struct_t >
std::string tpcrs::ConfigStruct< Base_t, Chair_t, Struct_t >::name{};
made gcc happy but crashes clang (and tons of warnings in cling). My solution is to add
// suppress warnings in clang (and CLING)
#if defined(__clang__) || defined(__CLING__)
template< typename Base_t, typename Chair_t, typename Struct_t >
  std::string ConfigStruct< Base_t, Chair_t, Struct_t >::name{};
#endif
to include/tpcrs/detail/config_structs.h. That compiles it with gcc and clang and loads it into cling without warnings.

To compile it with clang, use clang 9 installation under /opt/sphenix/utils (you might have to source the sphenix setup script to set this up correctly)
ccmake -i -DCMAKE_CXX_COMPILER=/opt/sphenix/utils/bin/clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=<installation area> -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_SKIP_INSTALL_RPATH=ON -DCMAKE_SKIP_RPATH=ON -DCMAKE_VERBOSE_MAKEFILE=ON ../
